### PR TITLE
Security fix for Prototype Pollution vulnerability

### DIFF
--- a/src/set.ts
+++ b/src/set.ts
@@ -25,6 +25,9 @@ function propSetter(object: Object, path: string, value: any): Object {
 		const type: string = typeof value;
 		return value !== null && (type === 'object' || type === 'function');
 	}
+	function isBlackListed(key: string): boolean {
+		return /^__proto__|constructor|prototype$/.test(key);
+	}
 
 	if (!isObject(object) || typeof path !== 'string') {
 		return JSON.parse(JSON.stringify(object));
@@ -35,6 +38,10 @@ function propSetter(object: Object, path: string, value: any): Object {
 
 	for (let i: number = 0; i < pathAr.length; i++) {
 		const p = pathAr[i];
+
+		if(isBlackListed(p)) {
+			return;
+		}
 
 		if (!isObject(object[p])) {
 			object[p] = {};


### PR DESCRIPTION
### :bar_chart: Metadata *

`propx` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-propx

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const propx = require('propx')

console.log('Before:', {}.polluted)
propx.set({}, '__proto__.polluted', true)
console.log('After:', {}.polluted)
```
2. Execute the following commands in terminal:
```bash
npm i propx # Install vulerable package
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/115116348-aa99c300-9fb6-11eb-8fa4-b7c6def2a3c8.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
